### PR TITLE
Vpalii clean room ws8

### DIFF
--- a/tdd_intro/cleanroom/chatclient/IGui.h
+++ b/tdd_intro/cleanroom/chatclient/IGui.h
@@ -6,4 +6,5 @@ class IGui
 public:
     virtual ~IGui() {}
     virtual void Print(const std::string& text) = 0;
+    virtual void Exit() = 0;
 };

--- a/tdd_intro/cleanroom/chatclient/ISocketWrapper.h
+++ b/tdd_intro/cleanroom/chatclient/ISocketWrapper.h
@@ -13,4 +13,5 @@ public:
     virtual SockPtr Accept() = 0;
     virtual void Read(std::string& buffer) = 0;
     virtual void Write(const std::string& buffer) = 0;
+    virtual void Close() = 0;
 };

--- a/tdd_intro/cleanroom/chatclient/session.cpp
+++ b/tdd_intro/cleanroom/chatclient/session.cpp
@@ -19,6 +19,17 @@ namespace
             return socketServer;
         }
     }
+
+    void WriteHandshake(ISocketWrapper& socket, const std::string& nickName)
+    {
+        socket.Write(nickName + ":HELLO!");
+    }
+
+    void ReadHandshake(ISocketWrapper& socket)
+    {
+        std::string handshake;
+        socket.Read(handshake);
+    }
 }
 
 Session::Session(ISocketWrapper& socket, IGui& gui, const std::string& nickName)
@@ -27,14 +38,12 @@ Session::Session(ISocketWrapper& socket, IGui& gui, const std::string& nickName)
     auto socketConnection = InitSession(socket, gui, isClient);
     if (isClient)
     {
-        socketConnection->Write(nickName + ":HELLO!");
-        std::string handshakeAnswer;
-        socketConnection->Read(handshakeAnswer);
+        WriteHandshake(*socketConnection, nickName);
+        ReadHandshake(*socketConnection);
     }
     else
     {
-        std::string handshake;
-        socketConnection->Read(handshake);
-        socketConnection->Write(nickName + ":HELLO!");
+        ReadHandshake(*socketConnection);
+        WriteHandshake(*socketConnection, nickName);
     }
 }

--- a/tdd_intro/cleanroom/chatclient/session.cpp
+++ b/tdd_intro/cleanroom/chatclient/session.cpp
@@ -29,6 +29,10 @@ namespace
     {
         std::string handshake;
         socket.Read(handshake);
+        if (handshake == "")
+        {
+            socket.Close();
+        }
     }
 }
 

--- a/tdd_intro/cleanroom/chatclient/session.cpp
+++ b/tdd_intro/cleanroom/chatclient/session.cpp
@@ -25,7 +25,7 @@ namespace
         socket.Write(nickName + ":HELLO!");
     }
 
-    void ReadHandshake(ISocketWrapper& socket)
+    std::string ReadHandshake(ISocketWrapper& socket)
     {
         std::string handshake;
         socket.Read(handshake);
@@ -33,6 +33,7 @@ namespace
         {
             socket.Close();
         }
+        return handshake;
     }
 }
 
@@ -43,7 +44,11 @@ Session::Session(ISocketWrapper& socket, IGui& gui, const std::string& nickName)
     if (isClient)
     {
         WriteHandshake(*socketConnection, nickName);
-        ReadHandshake(*socketConnection);
+        const std::string handshake = ReadHandshake(*socketConnection);
+        if (handshake == "")
+        {
+            gui.Print("Error: Invalid handshake received, exiting.");
+        }
     }
     else
     {

--- a/tdd_intro/cleanroom/chatclient/socketwrapper.cpp
+++ b/tdd_intro/cleanroom/chatclient/socketwrapper.cpp
@@ -40,7 +40,7 @@ SocketWrapper::SocketWrapper(SOCKET & other)
 
 SocketWrapper::~SocketWrapper()
 {
-    closesocket(m_socket);
+    Close();
 }
 
 void SocketWrapper::Bind(const std::string& addr, int16_t port)
@@ -100,4 +100,9 @@ void SocketWrapper::Read(std::string& /*buffer*/)
 void SocketWrapper::Write(const std::string& buffer)
 {
     send(m_socket, buffer.data(), buffer.size(), 0);
+}
+
+void SocketWrapper::Close()
+{
+    closesocket(m_socket);
 }

--- a/tdd_intro/cleanroom/chatclient/socketwrapper.h
+++ b/tdd_intro/cleanroom/chatclient/socketwrapper.h
@@ -14,6 +14,7 @@ public:
     virtual SockPtr Connect(const std::string& addr, int16_t port) override;
     void Read(std::string& buffer) override;
     void Write(const std::string& buffer) override;
+    void Close() override;
 
 private:
     SOCKET m_socket;

--- a/tdd_intro/cleanroom/chatclient/test.cpp
+++ b/tdd_intro/cleanroom/chatclient/test.cpp
@@ -157,5 +157,15 @@ TEST(SocketConnectionTest, ClientClosesSocketOnInvalidHandshakeAnswer)
     Session(mock, gui, "metizik");
 }
 
+TEST(SocketConnectionTest, ClientPrintsMessageOnInvalidHandshakeAnswer)
+{
+    MockSocketWrapper mock;
+    MockGui gui;
+    std::shared_ptr<MockSocketWrapper> acceptedSocket = TestSubcase::SetupClientPreconditions(mock);
+    EXPECT_CALL(*acceptedSocket, Read(_)).WillOnce(SetArgReferee<0>(""));
+    EXPECT_CALL(gui, Print("Error: Invalid handshake received, exiting."));
+    Session(mock, gui, "metizik");
+}
+
 // Sample for set reference:
 //    EXPECT_CALL(*clientMock, Read(_)).WillOnce(SetArgReferee<0>("server:HELLO!"));

--- a/tdd_intro/cleanroom/chatclient/test.cpp
+++ b/tdd_intro/cleanroom/chatclient/test.cpp
@@ -52,6 +52,7 @@ public:
     MOCK_METHOD0(Accept, ISocketWrapper::SockPtr());
     MOCK_METHOD1(Read, void(std::string& nickName));
     MOCK_METHOD1(Write, void(const std::string& nickName));
+    MOCK_METHOD0(Close, void());
 };
 
 class MockGui : public IGui
@@ -142,6 +143,18 @@ TEST(SocketConnectionTest, ClientReadsHandshakeAnswer)
     EXPECT_CALL(*acceptedSocket, Write("metizik:HELLO!"));
     EXPECT_CALL(*acceptedSocket, Read(_));
     Session(mock, gui, "metizik");
+}
+
+TEST(SocketConnectionTest, ClientHandlesInvalidHandshakeAnswer)
+{
+    MockSocketWrapper mock;
+    MockGui gui;
+    std::shared_ptr<MockSocketWrapper> acceptedSocket = TestSubcase::SetupClientPreconditions(mock);
+    EXPECT_CALL(*acceptedSocket, Write("metizik:HELLO!"));
+    EXPECT_CALL(*acceptedSocket, Read(_)).WillOnce(SetArgReferee<0>(""));
+    EXPECT_CALL(*acceptedSocket, Close());
+    EXPECT_CALL(gui, Print("Error: Invalid handshake received, exiting."));
+    EXPECT_ANY_THROW(Session(mock, gui, "metizik"));
 }
 
 // Sample for set reference:

--- a/tdd_intro/cleanroom/chatclient/test.cpp
+++ b/tdd_intro/cleanroom/chatclient/test.cpp
@@ -134,5 +134,15 @@ TEST(SocketConnectionTest, ServerAnswersOnHandshake)
     Session(mock, gui, "server");
 }
 
+TEST(SocketConnectionTest, ClientReadsHandshakeAnswer)
+{
+    MockSocketWrapper mock;
+    MockGui gui;
+    std::shared_ptr<MockSocketWrapper> acceptedSocket = TestSubcase::SetupClientPreconditions(mock);
+    EXPECT_CALL(*acceptedSocket, Write("metizik:HELLO!"));
+    EXPECT_CALL(*acceptedSocket, Read(_));
+    Session(mock, gui, "metizik");
+}
+
 // Sample for set reference:
 //    EXPECT_CALL(*clientMock, Read(_)).WillOnce(SetArgReferee<0>("server:HELLO!"));

--- a/tdd_intro/cleanroom/chatclient/test.cpp
+++ b/tdd_intro/cleanroom/chatclient/test.cpp
@@ -146,7 +146,7 @@ TEST(SocketConnectionTest, ClientReadsHandshakeAnswer)
     Session(mock, gui, "metizik");
 }
 
-TEST(SocketConnectionTest, ClientHandlesInvalidHandshakeAnswer)
+TEST(SocketConnectionTest, ClientClosesSocketOnInvalidHandshakeAnswer)
 {
     MockSocketWrapper mock;
     MockGui gui;
@@ -154,8 +154,6 @@ TEST(SocketConnectionTest, ClientHandlesInvalidHandshakeAnswer)
     EXPECT_CALL(*acceptedSocket, Write("metizik:HELLO!"));
     EXPECT_CALL(*acceptedSocket, Read(_)).WillOnce(SetArgReferee<0>(""));
     EXPECT_CALL(*acceptedSocket, Close());
-    EXPECT_CALL(gui, Print("Error: Invalid handshake received, exiting."));
-    EXPECT_CALL(gui, Exit());
     Session(mock, gui, "metizik");
 }
 

--- a/tdd_intro/cleanroom/chatclient/test.cpp
+++ b/tdd_intro/cleanroom/chatclient/test.cpp
@@ -59,6 +59,7 @@ class MockGui : public IGui
 {
 public:
     MOCK_METHOD1(Print, void(const std::string&));
+    MOCK_METHOD0(Exit, void());
 };
 
 namespace TestSubcase
@@ -154,7 +155,8 @@ TEST(SocketConnectionTest, ClientHandlesInvalidHandshakeAnswer)
     EXPECT_CALL(*acceptedSocket, Read(_)).WillOnce(SetArgReferee<0>(""));
     EXPECT_CALL(*acceptedSocket, Close());
     EXPECT_CALL(gui, Print("Error: Invalid handshake received, exiting."));
-    EXPECT_ANY_THROW(Session(mock, gui, "metizik"));
+    EXPECT_CALL(gui, Exit());
+    Session(mock, gui, "metizik");
 }
 
 // Sample for set reference:


### PR DESCRIPTION
I'm stuck on refactoring after satisfying ClientPrintsMessageOnInvalidHandshakeAnswer test.
When I move gui.Print inside ReadHandshake, it breaks ClientPrintsMessageOnInvalidHandshakeAnswer.
When I move socket.Close outside of ReadHandshake, it breaks both moveMessageIsDispayedAfterUnsuccesfulConnect and ServerAnswersOnHandshake.